### PR TITLE
Fix bug for duplicate first/last paths

### DIFF
--- a/tasks/sass-import.js
+++ b/tasks/sass-import.js
@@ -50,12 +50,12 @@ module.exports = function(grunt) {
               }
 
               // Discard if already included in *first*
-              if (('first' in path) && (path.first.indexOf(file.name) != -1)) {
+              if (('first' in path) && (options.basePath.concat(path.first).indexOf(file.name) != -1)) {
                 return;
               }
 
               // Discard if present in *last*
-              if (('last' in path) && (path.last.indexOf(file.name) != -1)) {
+              if (('last' in path) && (options.basePath.concat(path.last).indexOf(file.name) != -1)) {
                 return;
               }
 


### PR DESCRIPTION
The basePath isn't included in the first/last checks within the “Handling regular files” closure. This causes the first and last import paths to be duplicated when using the basePath option.

```
sass_import: {
  options: {
    basePath: 'sass/'
  },
  files: {
    'main.scss': [{path: 'global/*', last: 'global/headings.scss'}]
  }
}
```

```
@import 'global/headings';
@import 'global/modules';
@import 'global/variables';
@import 'global/headings';
```
