### PR TITLE
Fix for Windows backslashes

### DIFF
--- a/tasks/sass-import.js
+++ b/tasks/sass-import.js
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
         }
 
         resultFiles.forEach(function (file) {
-          file = nodePath.relative(destRoot, file);
+          file = nodePath.relative(destRoot, file).replace(/\\/g, '/');
           output += buildOutputLine(file.replace(options.basePath, ''));
         });
       });


### PR DESCRIPTION
added replace method to swap out Windows backslashes for Unix forward slashes
