### PR TITLE
Add "sassImport" alias wrapper task

### DIFF
--- a/tasks/sass-import.js
+++ b/tasks/sass-import.js
@@ -112,5 +112,10 @@ module.exports = function(grunt) {
       return '@import \'' + file + '\';\n';
     }
   });
+  
+  grunt.registerMultiTask('sassImport', 'Glob functionality for loading Sass partials', function () {
+    grunt.config.set('sass_import', grunt.config.get('sassImport'));
+    grunt.task.run('sass_import');
+  });
 
 };


### PR DESCRIPTION
This adds the ability to use `sassImport` as the task name, whilst retaining the old name to avoid breaking previous installs. This is required as jscs requires names to be in camelCase by default. The default installation of the Angular Yeoman generator (a very popular setup) scans the Gruntfile.js file. Using the underscored name causes an exception.
